### PR TITLE
Update keywords for Gatsby Plugin Library

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,10 @@
   "name": "gatsby-plugin-i18n-extension",
   "description": "Extension for gatsby-plugin-i18n with ContextProvider and utils",
   "version": "1.1.0",
+  "keywords": [
+    "gatsby",
+    "gatsby-plugin"
+    ],
   "author": "Fabian Todt <fabian@fabiantodt.at>",
   "repository": "https://github.com/gaambo/gatsby-plugin-i18n-extension",
   "bugs": {


### PR DESCRIPTION
Hi there!

I noticed that your `package.json` was missing the keyword `gatsby-plugin`. This keyword will enable this plugin to be included in the Gatsby Plugin Library. You can check [Gatsby's documentation](https://www.gatsbyjs.org/contributing/submit-to-plugin-library/) on how plugins are added.

cc: [Gatsby PR](https://github.com/gatsbyjs/gatsby/issues/14013) for more information about the plugin.